### PR TITLE
Generic type `YEvent<T>` requires 1 type argument(s)

### DIFF
--- a/packages/immer-yjs/src/immer-yjs.ts
+++ b/packages/immer-yjs/src/immer-yjs.ts
@@ -8,7 +8,7 @@ enablePatches()
 
 export type Snapshot = JSONObject | JSONArray
 
-function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent) {
+function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<any>) {
     if (event instanceof Y.YMapEvent && isJSONObject(base)) {
         const source = event.target as Y.Map<any>
 
@@ -46,7 +46,7 @@ function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent) {
     }
 }
 
-function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent[]) {
+function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent<any>[]) {
     return produce(snapshot, (target) => {
         for (const event of events) {
             const base = event.path.reduce((obj, step) => {
@@ -192,7 +192,7 @@ export function bind<S extends Snapshot>(source: Y.Map<any> | Y.Array<any>, opti
         return () => void subscription.delete(fn)
     }
 
-    const observer = (events: Y.YEvent[]) => {
+    const observer = (events: Y.YEvent<any>[]) => {
         snapshot = applyYEvents(get(), events)
         subscription.forEach((fn) => fn(get()))
     }


### PR DESCRIPTION
We have just imported `immer-yjs` into our project (and has been great so far!), but it is causing our build to fail. (Even with `skipModuleCheck: true` set in tsconfig, which is odd and we need to figure out)

The issue stems from the `YEvent` type needing a type argument. 

```
../../node_modules/.pnpm/immer-yjs@0.1.4_immer@9.0.12+yjs@13.5.34/node_modules/immer-yjs/src/immer-yjs.ts:11:59 - error TS2314: Generic type 'YEvent<T>' requires 1 type argument(s).

11 function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent) {
                                                             ~~~~~~~~

../../node_modules/.pnpm/immer-yjs@0.1.4_immer@9.0.12+yjs@13.5.34/node_modules/immer-yjs/src/immer-yjs.ts:49:64 - error TS2314: Generic type 'YEvent<T>' requires 1 type argument(s).

49 function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent[]) {
                                                                  ~~~~~~~~

../../node_modules/.pnpm/immer-yjs@0.1.4_immer@9.0.12+yjs@13.5.34/node_modules/immer-yjs/src/immer-yjs.ts:52:45 - error TS7006: Parameter 'obj' implicitly has an 'any' type.

52             const base = event.path.reduce((obj, step) => {
                                               ~~~

../../node_modules/.pnpm/immer-yjs@0.1.4_immer@9.0.12+yjs@13.5.34/node_modules/immer-yjs/src/immer-yjs.ts:52:50 - error TS7006: Parameter 'step' implicitly has an 'any' type.

52             const base = event.path.reduce((obj, step) => {
                                                    ~~~~

../../node_modules/.pnpm/immer-yjs@0.1.4_immer@9.0.12+yjs@13.5.34/node_modules/immer-yjs/src/immer-yjs.ts:195:31 - error TS2314: Generic type 'YEvent<T>' requires 1 type argument(s).

195     const observer = (events: Y.YEvent[]) => {
                                  ~~~~~~~~

Found 5 errors in the same file, starting at: ../../node_modules/.pnpm/immer-yjs@0.1.4_immer@9.0.12+yjs@13.5.34/node_modules/immer-yjs/src/immer-yjs.ts:11
```

Adding a generic type argument of `any` fixes the the type issue. If there is a better type argument, I would be happy to update the PR with it!