### PR TITLE
docs: copy root readme on publish

### DIFF
--- a/packages/immer-yjs/package.json
+++ b/packages/immer-yjs/package.json
@@ -25,7 +25,8 @@
         "build": "tsc && vite build",
         "test": "NODE_NO_WARNINGS=1 vitest",
         "coverage": "vitest run --coverage",
-        "release": "standard-version",
+        "copy-readme": "cp ../../README.md README.md",
+        "release": "yarn copy-readme && standard-version",
         "check:types": "tsc --noEmit"
     },
     "peerDependencies": {


### PR DESCRIPTION
When releasing, copy the readme file from the repository root to the immer-yjs workspace that is being published. In this way, users on NPM don not need to navigate to GitHub.

Normally, I'd handle the publishing in CI/CD and as such include this as a step in a publishing workflow. But in this repo, such workflows does not exist; instead, I will publish locally.