### PR TITLE
chore: upgrade Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 .pnp.cjs
 .pnp.loader.mjs
+.yarn

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "prettier": "^2.5.1",
+        "prettier": "^3.4.2",
         "vite": "^2.8.4"
     },
     "packageManager": "yarn@4.6.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "eslint": "^8.10.0",
         "eslint-config-prettier": "^8.4.0",
         "eslint-plugin-import": "^2.25.4",
-        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "prettier": "^3.4.2",
         "vite": "^2.8.4"

--- a/packages/immer-yjs/CHANGELOG.md
+++ b/packages/immer-yjs/CHANGELOG.md
@@ -6,20 +6,20 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### ⚠ BREAKING CHANGES
 
--   update deps to latest
+- update deps to latest
 
 ### Features
 
--   add option to configure applyPatch ([41cb3e8](https://github.com/sep2/immer-yjs/commit/41cb3e8dd316bbfd19045aba2590ccb331be523d))
--   export default bind ([e54e3cc](https://github.com/sep2/immer-yjs/commit/e54e3cca0a8df6971fbe821be00af3440bcd5b9e))
+- add option to configure applyPatch ([41cb3e8](https://github.com/sep2/immer-yjs/commit/41cb3e8dd316bbfd19045aba2590ccb331be523d))
+- export default bind ([e54e3cc](https://github.com/sep2/immer-yjs/commit/e54e3cca0a8df6971fbe821be00af3440bcd5b9e))
 
 ### Bug Fixes
 
--   bundle badge ([a1c77dd](https://github.com/sep2/immer-yjs/commit/a1c77dded078b33e8f0c1507847052b21589b59d))
--   handle replace array.length operation ([e4fbe7a](https://github.com/sep2/immer-yjs/commit/e4fbe7a17f311a7d885ed7e4a67ce854c8dafd1e))
--   support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
+- bundle badge ([a1c77dd](https://github.com/sep2/immer-yjs/commit/a1c77dded078b33e8f0c1507847052b21589b59d))
+- handle replace array.length operation ([e4fbe7a](https://github.com/sep2/immer-yjs/commit/e4fbe7a17f311a7d885ed7e4a67ce854c8dafd1e))
+- support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
 
--   update deps to latest ([d53c096](https://github.com/sep2/immer-yjs/commit/d53c0969cf459423648e7dc723eae5a7c7826d70))
+- update deps to latest ([d53c096](https://github.com/sep2/immer-yjs/commit/d53c0969cf459423648e7dc723eae5a7c7826d70))
 
 ## 1.0.0 (2022-04-27)
 
@@ -27,45 +27,45 @@ Bump to 1.0.0 because of this issue [standard-version#539](https://github.com/co
 
 ### ⚠ BREAKING CHANGES
 
--   update deps to latest
+- update deps to latest
 
 ### Features
 
--   add option to configure applyPatch ([41cb3e8](https://github.com/sep2/immer-yjs/commit/41cb3e8dd316bbfd19045aba2590ccb331be523d))
--   export default bind ([e54e3cc](https://github.com/sep2/immer-yjs/commit/e54e3cca0a8df6971fbe821be00af3440bcd5b9e))
+- add option to configure applyPatch ([41cb3e8](https://github.com/sep2/immer-yjs/commit/41cb3e8dd316bbfd19045aba2590ccb331be523d))
+- export default bind ([e54e3cc](https://github.com/sep2/immer-yjs/commit/e54e3cca0a8df6971fbe821be00af3440bcd5b9e))
 
 ### Bug Fixes
 
--   bundle badge ([a1c77dd](https://github.com/sep2/immer-yjs/commit/a1c77dded078b33e8f0c1507847052b21589b59d))
--   support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
+- bundle badge ([a1c77dd](https://github.com/sep2/immer-yjs/commit/a1c77dded078b33e8f0c1507847052b21589b59d))
+- support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
 
--   update deps to latest ([d53c096](https://github.com/sep2/immer-yjs/commit/d53c0969cf459423648e7dc723eae5a7c7826d70))
+- update deps to latest ([d53c096](https://github.com/sep2/immer-yjs/commit/d53c0969cf459423648e7dc723eae5a7c7826d70))
 
 ### [0.1.4](https://github.com/sep2/immer-yjs/compare/v0.1.3...v0.1.4) (2022-03-17)
 
 ### Bug Fixes
 
--   bundle badge ([a1c77dd](https://github.com/sep2/immer-yjs/commit/a1c77dded078b33e8f0c1507847052b21589b59d))
+- bundle badge ([a1c77dd](https://github.com/sep2/immer-yjs/commit/a1c77dded078b33e8f0c1507847052b21589b59d))
 
 ### 0.1.3 (2022-03-08)
 
 ### Features
 
--   add option to configure applyPatch ([41cb3e8](https://github.com/sep2/immer-yjs/commit/41cb3e8dd316bbfd19045aba2590ccb331be523d))
--   export default bind ([e54e3cc](https://github.com/sep2/immer-yjs/commit/e54e3cca0a8df6971fbe821be00af3440bcd5b9e))
+- add option to configure applyPatch ([41cb3e8](https://github.com/sep2/immer-yjs/commit/41cb3e8dd316bbfd19045aba2590ccb331be523d))
+- export default bind ([e54e3cc](https://github.com/sep2/immer-yjs/commit/e54e3cca0a8df6971fbe821be00af3440bcd5b9e))
 
 ### Bug Fixes
 
--   support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
+- support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
 
 ### 0.1.2 (2022-03-08)
 
 ### Features
 
--   add option to configure applyPatch ([d20b970](https://github.com/sep2/immer-yjs/commit/d20b970c4a75801230b3eb6094d290db62386e6d))
+- add option to configure applyPatch ([d20b970](https://github.com/sep2/immer-yjs/commit/d20b970c4a75801230b3eb6094d290db62386e6d))
 
 ### 0.0.9 (2022-03-04)
 
 ### Bug Fixes
 
--   support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))
+- support mutating root type ([0a42efe](https://github.com/sep2/immer-yjs/commit/0a42efed8c2249d640d9bbcf4279fe3d555d7560))

--- a/readme.md
+++ b/readme.md
@@ -9,13 +9,13 @@ Combine immer & y.js
 
 [immer](https://github.com/immerjs/immer) is a library for easy immutable data manipulation using plain json structure. [y.js](https://github.com/yjs/yjs) is a CRDT library with mutation-based API. `immer-yjs` allows manipulating `y.js` data types with the api provided by `immer`.
 
--   Two-way binding between y.js and plain (nested) json object/array.
--   Efficient snapshot update with structural sharing, same as `immer`.
--   Updates to `y.js` are explicitly batched in transaction, you control the transaction boundary.
--   Always opt-in, non-intrusive by nature (the snapshot is just a plain object after all).
--   The snapshot shape & y.js binding aims to be fully customizable.
--   Typescript all the way (pure js is also supported).
--   Code is simple and small, no magic hidden behind, no vendor-locking.
+- Two-way binding between y.js and plain (nested) json object/array.
+- Efficient snapshot update with structural sharing, same as `immer`.
+- Updates to `y.js` are explicitly batched in transaction, you control the transaction boundary.
+- Always opt-in, non-intrusive by nature (the snapshot is just a plain object after all).
+- The snapshot shape & y.js binding aims to be fully customizable.
+- Typescript all the way (pure js is also supported).
+- Code is simple and small, no magic hidden behind, no vendor-locking.
 
 Do:
 
@@ -131,7 +131,7 @@ Please submit with sample code by PR, helps needed.
 
 Data will sync between multiple browser tabs automatically.
 
--   [Messages Object](https://codesandbox.io/s/immer-yjs-demo-6e0znb)
+- [Messages Object](https://codesandbox.io/s/immer-yjs-demo-6e0znb)
 
 # Changelog
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pkgr/core@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "@pkgr/core@npm:0.1.1"
+  checksum: 10/6f25fd2e3008f259c77207ac9915b02f1628420403b2630c92a07ff963129238c9262afc9e84344c7a23b5cc1f3965e2cd17e3798219f5fd78a63d144d3cceba
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^5.1.0":
   version: 5.1.0
   resolution: "@rollup/pluginutils@npm:5.1.0"
@@ -2011,18 +2018,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "eslint-plugin-prettier@npm:4.0.0"
+"eslint-plugin-prettier@npm:^5.2.3":
+  version: 5.2.3
+  resolution: "eslint-plugin-prettier@npm:5.2.3"
   dependencies:
     prettier-linter-helpers: "npm:^1.0.0"
+    synckit: "npm:^0.9.1"
   peerDependencies:
-    eslint: ">=7.28.0"
-    prettier: ">=2.0.0"
+    "@types/eslint": ">=8.0.0"
+    eslint: ">=8.0.0"
+    eslint-config-prettier: "*"
+    prettier: ">=3.0.0"
   peerDependenciesMeta:
+    "@types/eslint":
+      optional: true
     eslint-config-prettier:
       optional: true
-  checksum: 10/8948229771563907bf3455375f46ef53dd2f2b6e4d86f7e0b0408d91cb6dc89d7a72af3c0ae820abcd4cdfcf56be3e3db387ee7aa1937df86715a03ea7cefed6
+  checksum: 10/6444a0b89f3e2a6b38adce69761133f8539487d797f1655b3fa24f93a398be132c4f68f87041a14740b79202368d5782aa1dffd2bd7a3ea659f263d6796acf15
   languageName: node
   linkType: hard
 
@@ -2753,7 +2765,7 @@ __metadata:
     eslint: "npm:^8.10.0"
     eslint-config-prettier: "npm:^8.4.0"
     eslint-plugin-import: "npm:^2.25.4"
-    eslint-plugin-prettier: "npm:^4.0.0"
+    eslint-plugin-prettier: "npm:^5.2.3"
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
     prettier: "npm:^3.4.2"
     vite: "npm:^2.8.4"
@@ -4644,6 +4656,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"synckit@npm:^0.9.1":
+  version: 0.9.2
+  resolution: "synckit@npm:0.9.2"
+  dependencies:
+    "@pkgr/core": "npm:^0.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/d45c4288be9c0232343650643892a7edafb79152c0c08d7ae5d33ca2c296b67a0e15f8cb5c9153969612c4ea5cd5686297542384aab977db23cfa6653fe02027
+  languageName: node
+  linkType: hard
+
 "tar@npm:^6.0.2, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
@@ -4751,6 +4773,13 @@ __metadata:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.2":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,7 +2755,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.25.4"
     eslint-plugin-prettier: "npm:^4.0.0"
     eslint-plugin-simple-import-sort: "npm:^7.0.0"
-    prettier: "npm:^2.5.1"
+    prettier: "npm:^3.4.2"
     vite: "npm:^2.8.4"
   languageName: unknown
   linkType: soft
@@ -2780,7 +2780,7 @@ __metadata:
 "immer@npm:^10.1.1":
   version: 10.1.1
   resolution: "immer@npm:10.1.1"
-  checksum: 9dacf1e8c201d69191ccd88dc5d733bafe166cd45a5a360c5d7c88f1de0dff974a94114d72b35f3106adfe587fcfb131c545856184a2247d89d735ad25589863
+  checksum: 10/9dacf1e8c201d69191ccd88dc5d733bafe166cd45a5a360c5d7c88f1de0dff974a94114d72b35f3106adfe587fcfb131c545856184a2247d89d735ad25589863
   languageName: node
   linkType: hard
 
@@ -3973,12 +3973,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "prettier@npm:2.5.1"
+"prettier@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "prettier@npm:3.4.2"
   bin:
-    prettier: bin-prettier.js
-  checksum: 10/c8f95df9ebe7241c557ab74237395adfed603719099aaf7cdb9b711c1a7fb7ac809c03fe68c22d0a6c0dbf1c4ab3c6eb90a6cc7bb31e4ea07a4a84fdbbb5c58f
+    prettier: bin/prettier.cjs
+  checksum: 10/a3e806fb0b635818964d472d35d27e21a4e17150c679047f5501e1f23bd4aa806adf660f0c0d35214a210d5d440da6896c2e86156da55f221a57938278dc326e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade prettier because the current version could not parse `satisfies`, which is a relatively new TypeScript feature. 

Then apply code formatting. The new Prettier version seems to format .md files slightly differently