### PR TITLE
ci: release-please

### DIFF
--- a/.github/workflows/code-integration-checks.yml
+++ b/.github/workflows/code-integration-checks.yml
@@ -9,9 +9,9 @@ jobs:
         name: Code Integration Checks
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Set up node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: 'yarn'

--- a/.github/workflows/code-integration-checks.yml
+++ b/.github/workflows/code-integration-checks.yml
@@ -1,5 +1,8 @@
 name: 'Code Integration Checks'
-on: ['pull_request']
+on:
+    pull_request:
+    workflow_call:
+
 jobs:
     integration-checks:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,17 @@ jobs:
                   node-version: 22
                   cache: 'yarn'
                   registry-url: 'https://registry.npmjs.org'
+            # `npm stage publish` requires npm >= 11.15.0, but Node 22 ships npm 10.
+            - name: Update npm (staged publishing support)
+              run: npm install -g npm@^11.15.0
             - name: Install
               run: yarn install --immutable
             - name: Build
               run: yarn build
             - name: Copy readme into package
               run: yarn workspace immer-yjs copy-readme
-            - name: Publish to npm
-              run: npm publish --access public
+            - name: Stage publish to npm (awaits 2FA approval)
+              run: npm stage publish --access public
               working-directory: packages/immer-yjs
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+permissions:
+    id-token: write
+    contents: read
+
+jobs:
+    ci:
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/workflows/code-integration-checks.yml
+
+    publish-npm:
+        name: Publish NPM
+        needs: ci
+        if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: 'yarn'
+                  registry-url: 'https://registry.npmjs.org'
+            - name: Update npm (OIDC trusted publishing support)
+              run: npm install -g npm@latest
+            - name: Install
+              run: yarn install --immutable
+            - name: Build
+              run: yarn build
+            - name: Copy readme into package
+              run: yarn workspace immer-yjs copy-readme
+            - name: Publish to npm (OIDC, with provenance)
+              run: npm publish --provenance --access public
+              working-directory: packages/immer-yjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
             # `npm stage publish` requires npm >= 11.15.0, but Node 22 ships npm 10.
             - name: Update npm (staged publishing support)
-              run: npm install -g npm@^11.15.0
+              run: npm install -g npm@11.15.0
             - name: Install
               run: yarn install --immutable
             - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish
 
 on:
     workflow_call:
+        secrets:
+            NPM_TOKEN:
+                required: true
     workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     workflow_dispatch:
 
 permissions:
-    id-token: write
     contents: read
 
 jobs:
@@ -26,14 +25,14 @@ jobs:
                   node-version: 22
                   cache: 'yarn'
                   registry-url: 'https://registry.npmjs.org'
-            - name: Update npm (OIDC trusted publishing support)
-              run: npm install -g npm@latest
             - name: Install
               run: yarn install --immutable
             - name: Build
               run: yarn build
             - name: Copy readme into package
               run: yarn workspace immer-yjs copy-readme
-            - name: Publish to npm (OIDC, with provenance)
-              run: npm publish --provenance --access public
+            - name: Publish to npm
+              run: npm publish --access public
               working-directory: packages/immer-yjs
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,6 @@ jobs:
         needs: release-please
         if: ${{ needs.release-please.outputs.release_created == 'true' }}
         permissions:
-            id-token: write
             contents: read
+        secrets: inherit
         uses: ./.github/workflows/publish.yml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,33 @@
+name: Release Please
+
+on:
+    push:
+        branches: [main]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    ci:
+        uses: ./.github/workflows/code-integration-checks.yml
+
+    release-please:
+        needs: ci
+        runs-on: ubuntu-latest
+        outputs:
+            release_created: ${{ steps.release.outputs.release_created }}
+        steps:
+            - uses: googleapis/release-please-action@v5
+              id: release
+              with:
+                  config-file: release-please-config.json
+                  manifest-file: .release-please-manifest.json
+
+    publish:
+        needs: release-please
+        if: ${{ needs.release-please.outputs.release_created == 'true' }}
+        permissions:
+            id-token: write
+            contents: read
+        uses: ./.github/workflows/publish.yml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,5 +29,6 @@ jobs:
         if: ${{ needs.release-please.outputs.release_created == 'true' }}
         permissions:
             contents: read
-        secrets: inherit
+        secrets:
+            NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: ./.github/workflows/publish.yml

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+    "packages/immer-yjs": "1.2.0"
+}

--- a/packages/immer-yjs/package.json
+++ b/packages/immer-yjs/package.json
@@ -25,7 +25,7 @@
         "build": "tsc && vite build",
         "test": "NODE_NO_WARNINGS=1 vitest",
         "coverage": "vitest run --coverage",
-        "copy-readme": "cp ../../README.md README.md",
+        "copy-readme": "cp ../../readme.md readme.md",
         "release": "yarn copy-readme && standard-version",
         "check:types": "tsc --noEmit"
     },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "node",
+    "include-component-in-tag": false,
+    "bootstrap-sha": "efa3b7e38f6b7b85817f71bc5876346de45b3122",
+    "packages": {
+        "packages/immer-yjs": {}
+    }
+}


### PR DESCRIPTION
release-please publishing workflow:

- You can run the publishing workflow manually via workflow_dispatch.
- The ci checks run before publishing
- It uses NPM token but publishes with staging

The workflow is modeled after the workflow in https://github.com/johannes-lindgren/pure-parse

## Blocker for OIDC

@sep2, I'd like to switch to OIDC, but for that I need to enable **"Allow GitHub Actions to create and approve pull requests"**, but I do not have admin rights to this repo.

1. Go to https://github.com/sep2/immer-yjs/settings/actions — or in the repo, Settings → Actions → General (left sidebar, under "Actions").
2. Scroll to the bottom section "Workflow permissions".
3. There you'll find the checkbox "Allow GitHub Actions to create and approve pull requests" — tick it and click Save.

I have already configured trusted publisher on NPM