### PR TITLE
feat!: any -> unknown

### DIFF
--- a/packages/immer-yjs/eslint.config.mjs
+++ b/packages/immer-yjs/eslint.config.mjs
@@ -3,8 +3,8 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config({ ignores: ['dist'] }, js.configs.recommended, tseslint.configs.recommended, {
-    linterOptions:{
-        reportUnusedDisableDirectives: true
+    linterOptions: {
+        reportUnusedDisableDirectives: true,
     },
     languageOptions: {
         globals: {

--- a/packages/immer-yjs/eslint.config.mjs
+++ b/packages/immer-yjs/eslint.config.mjs
@@ -3,6 +3,9 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config({ ignores: ['dist'] }, js.configs.recommended, tseslint.configs.recommended, {
+    linterOptions:{
+        reportUnusedDisableDirectives: true
+    },
     languageOptions: {
         globals: {
             ...globals.browser,

--- a/packages/immer-yjs/src/immer-yjs.test.ts
+++ b/packages/immer-yjs/src/immer-yjs.test.ts
@@ -35,15 +35,16 @@ test('bind usage demo', () => {
     expect(snapshot1).toStrictEqual(map.toJSON())
 
     // get the reference to be compared after changes are made
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const yd1 = map.get(id1) as any
+    const yd1 = map.get(id1) as Y.Map<unknown>
+    const batters = yd1.get('batters') as Y.Map<unknown>
+    const batter = batters.get('batter') as Y.Array<unknown>
 
     // nested objects / arrays are properly converted to Y.Maps / Y.Arrays
     expect(yd1).toBeInstanceOf(Y.Map)
-    expect(yd1.get('batters')).toBeInstanceOf(Y.Map)
+    expect(batters).toBeInstanceOf(Y.Map)
     expect(yd1.get('topping')).toBeInstanceOf(Y.Array)
-    expect(yd1.get('batters').get('batter')).toBeInstanceOf(Y.Array)
-    expect(yd1.get('batters').get('batter').get(0).get('id')).toBeTypeOf('string')
+    expect(batter).toBeInstanceOf(Y.Array)
+    expect((batter.get(0) as Y.Map<unknown>).get('id')).toBeTypeOf('string')
 
     // update the state with immer
     binder.update((state) => {
@@ -84,16 +85,13 @@ test('bind usage demo', () => {
     // but yjs data type should not change reference (they are mutated in-place whenever possible)
     expect(map).toBe(doc.getMap(topLevelMap))
     expect(map.get(id1)).toBe(yd1)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((map.get(id1) as any).get('topping')).toBe(yd1.get('topping'))
+    expect((map.get(id1) as Y.Map<unknown>).get('topping')).toBe(yd1.get('topping'))
 
     // save the length for later comparison
     const expectLength = binder.get()[id1].batters.batter.length
 
     // change from y.js
-    yd1.get('batters')
-        .get('batter')
-        .push([{ id: '1005', type: 'test' }])
+    batter.push([{ id: '1005', type: 'test' }])
 
     // change reflected in snapshot
     expect(binder.get()[id1].batters.batter.at(-1)).toStrictEqual({ id: '1005', type: 'test' })
@@ -116,8 +114,7 @@ test('boolean in array', () => {
 
     const map = doc.getMap('data')
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const binder = bind<any>(map)
+    const binder = bind<{ k1?: boolean; k2?: boolean; k3?: boolean[] }>(map)
 
     binder.update((state) => {
         state.k1 = true

--- a/packages/immer-yjs/src/immer-yjs.ts
+++ b/packages/immer-yjs/src/immer-yjs.ts
@@ -10,13 +10,13 @@ export type Snapshot = JSONObject | JSONArray
 
 function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<Y.AbstractType<unknown>>) {
     if (event instanceof Y.YMapEvent && isJSONObject(base)) {
-        const source = event.target as Y.Map<unknown>
+        const source = event.target as Y.Map<Y.Map<unknown> | Y.Array<unknown> | JSONValue>
 
         event.changes.keys.forEach((change, key) => {
             switch (change.action) {
                 case 'add':
                 case 'update':
-                    base[key] = toPlainValue(source.get(key))
+                    base[key] = toPlainValue(source.get(key)!)
                     break
                 case 'delete':
                     delete base[key]
@@ -49,9 +49,13 @@ function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<Y.AbstractTyp
 function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent<Y.AbstractType<unknown>>[]) {
     return produce(snapshot, (target) => {
         for (const event of events) {
-            const base = event.path.reduce((obj, step) => {
-                return obj[step]
-            }, target)
+            const base = event.path.reduce(
+                (obj, step) => {
+                    return obj[step]
+                },
+                // @ts-expect-error -- walking the recursive draft by a dynamic path key is beyond the type system
+                target
+            )
 
             applyYEvent(base, event)
         }

--- a/packages/immer-yjs/src/immer-yjs.ts
+++ b/packages/immer-yjs/src/immer-yjs.ts
@@ -8,11 +8,9 @@ enablePatches()
 
 export type Snapshot = JSONObject | JSONArray
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<any>) {
+function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<Y.AbstractType<unknown>>) {
     if (event instanceof Y.YMapEvent && isJSONObject(base)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const source = event.target as Y.Map<any>
+        const source = event.target as Y.Map<unknown>
 
         event.changes.keys.forEach((change, key) => {
             switch (change.action) {
@@ -26,8 +24,7 @@ function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<any>) {
             }
         })
     } else if (event instanceof Y.YArrayEvent && isJSONArray(base)) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const arr = base as unknown as any[]
+        const arr = base as unknown as unknown[]
 
         let retain = 0
         event.changes.delta.forEach((change) => {
@@ -49,13 +46,10 @@ function applyYEvent<T extends JSONValue>(base: T, event: Y.YEvent<any>) {
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent<any>[]) {
+function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent<Y.AbstractType<unknown>>[]) {
     return produce(snapshot, (target) => {
         for (const event of events) {
             const base = event.path.reduce((obj, step) => {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 return obj[step]
             }, target)
 
@@ -68,8 +62,7 @@ const PATCH_REPLACE = 'replace'
 const PATCH_ADD = 'add'
 const PATCH_REMOVE = 'remove'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function defaultApplyPatch(target: Y.Map<any> | Y.Array<any>, patch: Patch) {
+function defaultApplyPatch(target: Y.Map<unknown> | Y.Array<unknown>, patch: Patch) {
     const { path, op, value } = patch
 
     if (!path.length) {
@@ -92,10 +85,10 @@ function defaultApplyPatch(target: Y.Map<any> | Y.Array<any>, patch: Patch) {
         return
     }
 
-    let base = target
+    let base: Y.Map<unknown> | Y.Array<unknown> = target
     for (let i = 0; i < path.length - 1; i++) {
         const step = path[i]
-        base = base.get(step as never)
+        base = base.get(step as never) as Y.Map<unknown> | Y.Array<unknown>
     }
 
     const property = path[path.length - 1]
@@ -136,8 +129,7 @@ function defaultApplyPatch(target: Y.Map<any> | Y.Array<any>, patch: Patch) {
 export type UpdateFn<S extends Snapshot> = (draft: S) => void
 
 function applyUpdate<S extends Snapshot>(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    source: Y.Map<any> | Y.Array<any>,
+    source: Y.Map<unknown> | Y.Array<unknown>,
     snapshot: S,
     fn: UpdateFn<S>,
     applyPatch: typeof defaultApplyPatch
@@ -185,8 +177,7 @@ export type Options<S extends Snapshot> = {
      * @param patch The patch that should be applied, please refer to 'immer' patch documentation.
      * @param applyPatch the default behavior to apply patch, call this to handle the normal case.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    applyPatch?: (target: Y.Map<any> | Y.Array<any>, patch: Patch, applyPatch: typeof defaultApplyPatch) => void
+    applyPatch?: (target: Y.Map<unknown> | Y.Array<unknown>, patch: Patch, applyPatch: typeof defaultApplyPatch) => void
 }
 
 /**
@@ -194,8 +185,7 @@ export type Options<S extends Snapshot> = {
  * @param source The y.js data type to bind.
  * @param options Change default behavior, can be omitted.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function bind<S extends Snapshot>(source: Y.Map<any> | Y.Array<any>, options?: Options<S>): Binder<S> {
+export function bind<S extends Snapshot>(source: Y.Map<unknown> | Y.Array<unknown>, options?: Options<S>): Binder<S> {
     let snapshot = source.toJSON() as S
 
     const get = () => snapshot
@@ -207,8 +197,7 @@ export function bind<S extends Snapshot>(source: Y.Map<any> | Y.Array<any>, opti
         return () => void subscription.delete(fn)
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const observer = (events: Y.YEvent<any>[]) => {
+    const observer = (events: Y.YEvent<Y.AbstractType<unknown>>[]) => {
         snapshot = applyYEvents(get(), events)
         subscription.forEach((fn) => fn(get()))
     }
@@ -219,8 +208,8 @@ export function bind<S extends Snapshot>(source: Y.Map<any> | Y.Array<any>, opti
     const applyPatchInOption = options ? options.applyPatch : undefined
 
     const applyPatch = applyPatchInOption
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (target: Y.Map<any> | Y.Array<any>, patch: Patch) => applyPatchInOption(target, patch, defaultApplyPatch)
+        ? (target: Y.Map<unknown> | Y.Array<unknown>, patch: Patch) =>
+              applyPatchInOption(target, patch, defaultApplyPatch)
         : defaultApplyPatch
 
     const update = (fn: UpdateFn<S>) => {

--- a/packages/immer-yjs/src/immer-yjs.ts
+++ b/packages/immer-yjs/src/immer-yjs.ts
@@ -50,10 +50,9 @@ function applyYEvents<S extends Snapshot>(snapshot: S, events: Y.YEvent<Y.Abstra
     return produce(snapshot, (target) => {
         for (const event of events) {
             const base = event.path.reduce(
-                (obj, step) => {
-                    return obj[step]
-                },
-                // @ts-expect-error -- walking the recursive draft by a dynamic path key is beyond the type system
+                (obj, step) =>
+                    // @ts-expect-error -- TODO runtime check
+                    obj[step],
                 target
             )
 

--- a/packages/immer-yjs/src/sample-data.ts
+++ b/packages/immer-yjs/src/sample-data.ts
@@ -1,5 +1,7 @@
 // Copied from https://opensource.adobe.com/Spry/samples/data_region/JSONDataSetSample.html
 
+import { JSONValue } from './types'
+
 export const id1 = '0001'
 export const id2 = '0002'
 export const id3 = '0003'
@@ -72,7 +74,7 @@ const sampleObject = {
     [data3.id]: data3,
 }
 
-function deepClone<T>(x: T): T {
+function deepClone<T extends JSONValue>(x: T): T {
     return JSON.parse(JSON.stringify(x)) as T
 }
 

--- a/packages/immer-yjs/src/sample-data.ts
+++ b/packages/immer-yjs/src/sample-data.ts
@@ -72,8 +72,8 @@ const sampleObject = {
     [data3.id]: data3,
 }
 
-function deepClone(x: unknown) {
-    return JSON.parse(JSON.stringify(x))
+function deepClone<T>(x: T): T {
+    return JSON.parse(JSON.stringify(x)) as T
 }
 
 export type SampleArrayType = typeof sampleArray

--- a/packages/immer-yjs/src/sample-data.ts
+++ b/packages/immer-yjs/src/sample-data.ts
@@ -72,8 +72,7 @@ const sampleObject = {
     [data3.id]: data3,
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function deepClone(x: any) {
+function deepClone(x: unknown) {
     return JSON.parse(JSON.stringify(x))
 }
 

--- a/packages/immer-yjs/src/types.ts
+++ b/packages/immer-yjs/src/types.ts
@@ -4,5 +4,4 @@ export type JSONValue = JSONPrimitive | JSONObject | JSONArray
 
 export type JSONObject = { [member: string]: JSONValue }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface JSONArray extends Array<JSONValue> {}
+export type JSONArray = JSONValue[]

--- a/packages/immer-yjs/src/util.ts
+++ b/packages/immer-yjs/src/util.ts
@@ -41,12 +41,11 @@ export function applyJsonObject(dest: Y.Map<unknown>, source: JSONObject) {
     })
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function toPlainValue(v: Y.Map<any> | Y.Array<any> | JSONValue) {
+export function toPlainValue(v: Y.Map<unknown> | Y.Array<unknown> | JSONValue) {
     if (v instanceof Y.Map || v instanceof Y.Array) {
         return v.toJSON() as JSONObject | JSONArray
     } else {
-        return v
+        return v as JSONValue
     }
 }
 


### PR DESCRIPTION
Swapping out all `any` to `unknown` in the library.

There is no runtime behaviour change, but the exposed types from the library contains `unknown` now instead of `any`.