### PR TITLE
feat: default Binder type argument to Snapshot

### DIFF
--- a/packages/immer-yjs/src/immer-yjs.test.ts
+++ b/packages/immer-yjs/src/immer-yjs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import * as Y from 'yjs'
 
-import { bind } from './immer-yjs'
+import { type Binder, bind } from './immer-yjs'
 import { createSampleObject, id1, id2, id3 } from './sample-data'
 
 test('bind usage demo', () => {
@@ -254,4 +254,17 @@ describe('array splice', () => {
         expect(result[2]).toBe(3)
         expect(result[3]).toBe(4)
     })
+})
+
+test('Binder can be annotated without a type argument', () => {
+    const doc = new Y.Doc()
+
+    // `Binder` defaults its type argument to `Snapshot`, matching how `bind`
+    // falls back to `Snapshot` when called without one. This annotation is the
+    // actual assertion: it fails to compile if the default is ever removed.
+    const binder: Binder = bind(doc.getMap('map'))
+
+    binder.update(() => ({ count: 1 }))
+
+    expect(binder.get()).toEqual({ count: 1 })
 })

--- a/packages/immer-yjs/src/immer-yjs.ts
+++ b/packages/immer-yjs/src/immer-yjs.ts
@@ -146,7 +146,7 @@ function applyUpdate<S extends Snapshot>(
 export type ListenerFn<S extends Snapshot> = (snapshot: S) => void
 export type UnsubscribeFn = () => void
 
-export type Binder<S extends Snapshot> = {
+export type Binder<S extends Snapshot = Snapshot> = {
     /**
      * Release the binder.
      */


### PR DESCRIPTION
Closes #25

`Binder` required an explicit type argument, while `bind` falls back to `Snapshot` when called without one. This defaults the parameter so the two are consistent:

```ts
export type Binder<S extends Snapshot = Snapshot> = { ... }
```

`Binder` can now be used as a bare annotation:

```ts
const binder: Binder = bind(doc.getMap('map'))
```